### PR TITLE
UseChunkFiles default true 

### DIFF
--- a/src/widgets/dashboard/utils/happ-routing-builder/happ-routing-builder.widget.tsx
+++ b/src/widgets/dashboard/utils/happ-routing-builder/happ-routing-builder.widget.tsx
@@ -87,7 +87,7 @@ export const HappRoutingBuilderWidget = () => {
         blockIp: '',
         domainStrategy: 'IPIfNonMatch',
         fakeDns: 'false',
-        useChunkFiles: 'false'
+        useChunkFiles: 'true'
     })
 
     const handleInputChange = (field: string, value: string) => {
@@ -504,7 +504,7 @@ export const HappRoutingBuilderWidget = () => {
                                                     onChange={(value) =>
                                                         handleInputChange(
                                                             'useChunkFiles',
-                                                            value || 'false'
+                                                            value || 'true'
                                                         )
                                                     }
                                                     styles={inputStyles}


### PR DESCRIPTION
По умолчанию в Happ это поле установлено в значение true, так как в большинстве случаев требуется нарезка геофайлов. Однако, если вы используете собственные геофайлы в формате JSON, это поле следует установить в false, что бы не дублировать в роутинге поля.