### PR TITLE
Add Russian translations

### DIFF
--- a/public/locales/ru/remnawave.json
+++ b/public/locales/ru/remnawave.json
@@ -941,8 +941,8 @@
             "show-custom-remarks": "Отображать кастомное примечание",
             "additional-response-headers": "Доп. хэдеры",
             "headers-that-will-be-sent-with-subscription-content": "Хэдеры будут отправлены вместе с содержимым подписки.",
-            "randomize-hosts": "Randomize hosts",
-            "randomize-hosts-description": "Randomize hosts in subscription content"
+            "randomize-hosts": "Перемешивать хосты",
+            "randomize-hosts-description": "Хосты в случайном порядке в содержимом подписки"
         }
     },
     "nodes-realtime-metrics": {


### PR DESCRIPTION
Переведено
"randomize-hosts": "Randomize hosts",
"randomize-hosts-description": "Randomize hosts in subscription content"