### PR TITLE
Add Cloudflare Access authentication settings

### DIFF
--- a/src/pages/auth/login/login.page.tsx
+++ b/src/pages/auth/login/login.page.tsx
@@ -1,22 +1,40 @@
 import { Badge, Box, Center, Divider, Group, Image, Stack, Text, Title } from '@mantine/core'
 import { GetStatusCommand } from '@remnawave/backend-contract'
-import { useMemo } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 
 import { OAuth2LoginButtonsFeature } from '@features/auth/oauth2-login-button/oauth2-login-button.feature'
 import { PasskeyLoginButtonFeature } from '@features/auth/passkey-login-button'
+import { useCloudflareAccessLogin } from '@shared/api/hooks/auth/auth.hooks'
 import { useGetAuthStatus } from '@shared/api/hooks/auth/auth.query.hooks'
 import { RegisterFormFeature } from '@features/auth/register-form'
 import { LoginFormFeature } from '@features/auth/login-form'
 import { parseColoredTextUtil } from '@shared/utils/misc'
+import { useAuth } from '@shared/hooks/use-auth'
 import { Logo, Page } from '@shared/ui'
 
+type TAuthStatusAuthentication =
+    NonNullable<GetStatusCommand.Response['response']['authentication']> & {
+        cloudflareAccess?: {
+            enabled: boolean
+        }
+    }
+
+type TAuthStatusWithCloudflareAccess = GetStatusCommand.Response['response'] & {
+    authentication: null | TAuthStatusAuthentication
+}
+
 const getAuthMethods = (authStatus: GetStatusCommand.Response['response'] | undefined) => {
+    const authStatusWithCloudflareAccess = authStatus as TAuthStatusWithCloudflareAccess | undefined
+
     const isPasswordEnabled = authStatus?.authentication?.password?.enabled ?? false
     const isPasskeyEnabled = authStatus?.authentication?.passkey?.enabled ?? false
+    const isCloudflareAccessEnabled =
+        authStatusWithCloudflareAccess?.authentication?.cloudflareAccess?.enabled ?? false
     const isOAuth2Enabled =
         Object.values(authStatus?.authentication?.oauth2?.providers ?? {}).some(Boolean) ?? false
 
     return {
+        isCloudflareAccessEnabled,
         isOAuth2Enabled,
         isPasskeyEnabled,
         isPasswordEnabled,
@@ -90,6 +108,9 @@ const AlternativeAuthMethods = ({
 
 export const LoginPage = () => {
     const { data: authStatus } = useGetAuthStatus()
+    const { setIsAuthenticated } = useAuth()
+    const isCloudflareAccessAttemptedRef = useRef(false)
+    const [isCloudflareAccessFailed, setIsCloudflareAccessFailed] = useState(false)
 
     const titleParts = useMemo(() => {
         if (authStatus?.branding.title) {
@@ -105,6 +126,32 @@ export const LoginPage = () => {
     const isRegister = !authStatus?.isLoginAllowed && authStatus?.isRegisterAllowed
     const authMethods = getAuthMethods(authStatus)
 
+    const { mutate: cloudflareAccessLogin, isPending: isCloudflareAccessPending } =
+        useCloudflareAccessLogin({
+            mutationFns: {
+                onSuccess() {
+                    setIsAuthenticated(true)
+                },
+                onError() {
+                    setIsCloudflareAccessFailed(true)
+                }
+            }
+        })
+
+    useEffect(() => {
+        if (
+            !authStatus?.isLoginAllowed ||
+            !authMethods.isCloudflareAccessEnabled ||
+            isCloudflareAccessAttemptedRef.current
+        ) {
+            return
+        }
+
+        isCloudflareAccessAttemptedRef.current = true
+        setIsCloudflareAccessFailed(false)
+        cloudflareAccessLogin({ variables: {} })
+    }, [authStatus?.isLoginAllowed, authMethods.isCloudflareAccessEnabled, cloudflareAccessLogin])
+
     return (
         <Page title="Login">
             <Stack align="center" gap="xs">
@@ -116,6 +163,18 @@ export const LoginPage = () => {
                 {!authStatus && (
                     <Badge color="cyan" mt={10} size="lg" variant="filled">
                         Server is not responding. Check logs.
+                    </Badge>
+                )}
+
+                {isCloudflareAccessPending && (
+                    <Badge color="orange" mt={10} size="lg" variant="light">
+                        Authenticating with Cloudflare Access...
+                    </Badge>
+                )}
+
+                {isCloudflareAccessFailed && (
+                    <Badge color="red" mt={10} size="lg" variant="light">
+                        Cloudflare Access authentication failed.
                     </Badge>
                 )}
 

--- a/src/pages/dashboard/remnawave-settings/components/remnawave-settings.page.component.tsx
+++ b/src/pages/dashboard/remnawave-settings/components/remnawave-settings.page.component.tsx
@@ -5,6 +5,7 @@ import { Container } from '@mantine/core'
 
 import { AuthentificationSettingsCardWidget } from '@widgets/remnawave-settings/authentification-settings-card/authentification-settings-card.widget'
 import { BrandingSettingsCardWidget } from '@widgets/remnawave-settings/branding-settings-card/branding-settings-card.widget'
+import { TCloudflareAccessSettings } from '@shared/api/hooks/remnawave-settings/remnawave-settings.mutation.hooks'
 import { ApiTokensCardWidget } from '@widgets/remnawave-settings/api-tokens-card/api-tokens-card.widget'
 import { LoadingScreen, Logo, Page, PageHeaderShared } from '@shared/ui'
 
@@ -15,6 +16,9 @@ interface IProps {
 
 export const RemnawaveSettingsPageComponent = (props: IProps) => {
     const { remnawaveSettings, apiTokensData } = props
+    const remnawaveSettingsWithCloudflareAccess = remnawaveSettings as typeof remnawaveSettings & {
+        cloudflareAccessSettings?: null | TCloudflareAccessSettings
+    }
 
     const { t } = useTranslation()
 
@@ -37,6 +41,9 @@ export const RemnawaveSettingsPageComponent = (props: IProps) => {
             <Container fluid p={0} size="xl">
                 <Masonry columns={{ 300: 1, 1400: 2, 2000: 3, 3000: 4 }} gap={16}>
                     <AuthentificationSettingsCardWidget
+                        cloudflareAccessSettings={
+                            remnawaveSettingsWithCloudflareAccess.cloudflareAccessSettings
+                        }
                         oauth2Settings={remnawaveSettings.oauth2Settings}
                         passkeySettings={remnawaveSettings.passkeySettings}
                         passwordSettings={remnawaveSettings.passwordSettings}

--- a/src/shared/api/hooks/auth/auth.hooks.ts
+++ b/src/shared/api/hooks/auth/auth.hooks.ts
@@ -6,12 +6,21 @@ import {
     VerifyPasskeyAuthenticationCommand
 } from '@remnawave/backend-contract'
 import { notifications } from '@mantine/notifications'
+import { z } from 'zod'
 
 import { setToken } from '@entities/auth/session-store'
 
 import { createMutationHook } from '../../tsq-helpers'
 
 export const AUTH_QUERY_KEY = 'auth'
+
+const CloudflareAccessResponseSchema = z.object({
+    response: z.object({
+        accessToken: z.string()
+    })
+})
+
+const CloudflareAccessRequestSchema = z.object({})
 
 export const useLogin = createMutationHook({
     endpoint: LoginCommand.TSQ_url,
@@ -80,6 +89,18 @@ export const useOAuth2Authorize = createMutationHook({
                 message: error.message,
                 color: 'red'
             })
+        }
+    }
+})
+
+export const useCloudflareAccessLogin = createMutationHook({
+    endpoint: '/api/auth/cloudflare-access',
+    bodySchema: CloudflareAccessRequestSchema,
+    responseSchema: CloudflareAccessResponseSchema,
+    requestMethod: 'post',
+    rMutationParams: {
+        onSuccess: (data) => {
+            setToken({ token: data.accessToken })
         }
     }
 })

--- a/src/shared/api/hooks/auth/auth.query.hooks.ts
+++ b/src/shared/api/hooks/auth/auth.query.hooks.ts
@@ -4,6 +4,7 @@ import {
 } from '@remnawave/backend-contract'
 import { createQueryKeys } from '@lukemorales/query-key-factory'
 import { keepPreviousData } from '@tanstack/react-query'
+import { z } from 'zod'
 
 import { sToMs } from '@shared/utils/time-utils'
 
@@ -18,9 +19,23 @@ export const authQueryKeys = createQueryKeys('auth', {
     }
 })
 
+const GetStatusResponseSchema = GetStatusCommand.ResponseSchema.extend({
+    response: GetStatusCommand.ResponseSchema.shape.response.extend({
+        authentication: z.nullable(
+            GetStatusCommand.ResponseSchema.shape.response.shape.authentication.unwrap().extend({
+                cloudflareAccess: z
+                    .object({
+                        enabled: z.boolean()
+                    })
+                    .default({ enabled: false })
+            })
+        )
+    })
+})
+
 export const useGetAuthStatus = createGetQueryHook({
     endpoint: GetStatusCommand.TSQ_url,
-    responseSchema: GetStatusCommand.ResponseSchema,
+    responseSchema: GetStatusResponseSchema,
     getQueryKey: () => authQueryKeys.getAuthStatus.queryKey,
     rQueryParams: {
         refetchOnMount: false,

--- a/src/shared/api/hooks/remnawave-settings/remnawave-settings.mutation.hooks.ts
+++ b/src/shared/api/hooks/remnawave-settings/remnawave-settings.mutation.hooks.ts
@@ -1,12 +1,35 @@
 import { UpdateRemnawaveSettingsCommand } from '@remnawave/backend-contract'
 import { notifications } from '@mantine/notifications'
+import { z } from 'zod'
 
 import { createMutationHook } from '../../tsq-helpers'
 
+export const CloudflareAccessSettingsSchema = z.object({
+    enabled: z.boolean(),
+    teamDomain: z.nullable(z.string()),
+    audience: z.nullable(z.string()),
+    emailAllowlistEnabled: z.boolean(),
+    allowedEmails: z.array(z.string()),
+    allowedDomains: z.array(z.string())
+})
+
+export type TCloudflareAccessSettings = z.infer<typeof CloudflareAccessSettingsSchema>
+
+export const UpdateRemnawaveSettingsRequestSchema =
+    UpdateRemnawaveSettingsCommand.RequestSchema.extend({
+        cloudflareAccessSettings: CloudflareAccessSettingsSchema.optional()
+    })
+
+const UpdateRemnawaveSettingsResponseSchema = UpdateRemnawaveSettingsCommand.ResponseSchema.extend({
+    response: UpdateRemnawaveSettingsCommand.ResponseSchema.shape.response.extend({
+        cloudflareAccessSettings: z.nullable(CloudflareAccessSettingsSchema).default(null)
+    })
+})
+
 export const useUpdateRemnawaveSettings = createMutationHook({
     endpoint: UpdateRemnawaveSettingsCommand.TSQ_url,
-    bodySchema: UpdateRemnawaveSettingsCommand.RequestSchema,
-    responseSchema: UpdateRemnawaveSettingsCommand.ResponseSchema,
+    bodySchema: UpdateRemnawaveSettingsRequestSchema,
+    responseSchema: UpdateRemnawaveSettingsResponseSchema,
     requestMethod: UpdateRemnawaveSettingsCommand.endpointDetails.REQUEST_METHOD,
     rMutationParams: {
         onSuccess: () => {

--- a/src/shared/api/hooks/remnawave-settings/remnawave-settings.query.hooks.ts
+++ b/src/shared/api/hooks/remnawave-settings/remnawave-settings.query.hooks.ts
@@ -1,8 +1,10 @@
 import { GetRemnawaveSettingsCommand } from '@remnawave/backend-contract'
 import { createQueryKeys } from '@lukemorales/query-key-factory'
+import { z } from 'zod'
 
 import { sToMs } from '@shared/utils/time-utils'
 
+import { CloudflareAccessSettingsSchema } from './remnawave-settings.mutation.hooks'
 import { createGetQueryHook, errorHandler } from '../../tsq-helpers'
 
 export const remnawaveSettingsQueryKeys = createQueryKeys('remnawaveSettings', {
@@ -11,9 +13,15 @@ export const remnawaveSettingsQueryKeys = createQueryKeys('remnawaveSettings', {
     }
 })
 
+const GetRemnawaveSettingsResponseSchema = GetRemnawaveSettingsCommand.ResponseSchema.extend({
+    response: GetRemnawaveSettingsCommand.ResponseSchema.shape.response.extend({
+        cloudflareAccessSettings: z.nullable(CloudflareAccessSettingsSchema).default(null)
+    })
+})
+
 export const useGetRemnawaveSettings = createGetQueryHook({
     endpoint: GetRemnawaveSettingsCommand.TSQ_url,
-    responseSchema: GetRemnawaveSettingsCommand.ResponseSchema,
+    responseSchema: GetRemnawaveSettingsResponseSchema,
     getQueryKey: () => remnawaveSettingsQueryKeys.getRemnawaveSettings.queryKey,
     rQueryParams: {
         refetchOnMount: false,

--- a/src/widgets/remnawave-settings/authentification-settings-card/authentification-settings-card.widget.tsx
+++ b/src/widgets/remnawave-settings/authentification-settings-card/authentification-settings-card.widget.tsx
@@ -17,17 +17,21 @@ import {
 } from '@remnawave/backend-contract'
 import { TbAlertCircle, TbFingerprint, TbKey, TbPassword, TbServer } from 'react-icons/tb'
 import { BiLogoGithub, BiLogoTelegram } from 'react-icons/bi'
+import { SiCloudflare, SiKeycloak } from 'react-icons/si'
 import { zodResolver } from 'mantine-form-zod-resolver'
 import { PiGlobe, PiKey } from 'react-icons/pi'
 import { useDisclosure } from '@mantine/hooks'
 import { useTranslation } from 'react-i18next'
-import { SiKeycloak } from 'react-icons/si'
 import { modals } from '@mantine/modals'
 import { useForm } from '@mantine/form'
 import { TFunction } from 'i18next'
 
+import {
+    TCloudflareAccessSettings,
+    UpdateRemnawaveSettingsRequestSchema,
+    useUpdateRemnawaveSettings
+} from '@shared/api/hooks/remnawave-settings/remnawave-settings.mutation.hooks'
 import { PasskeysDrawerComponent } from '@widgets/remnawave-settings/passkeys-settings-drawer/passkeys-drawer.component'
-import { useUpdateRemnawaveSettings } from '@shared/api/hooks/remnawave-settings/remnawave-settings.mutation.hooks'
 import { HelpActionIconShared, THelpDrawerAvailableScreen } from '@shared/ui/help-drawer'
 import { CheckboxCardShared } from '@shared/ui/checkbox-card/checkbox-card.shared'
 import { BaseOverlayHeader } from '@shared/ui/overlays/base-overlay-header'
@@ -38,6 +42,7 @@ import { handleFormErrors } from '@shared/utils/misc'
 import { queryClient } from '@shared/api'
 
 interface IProps {
+    cloudflareAccessSettings?: null | TCloudflareAccessSettings
     oauth2Settings: NonNullable<GetRemnawaveSettingsCommand.Response['response']['oauth2Settings']>
     passkeySettings: NonNullable<
         GetRemnawaveSettingsCommand.Response['response']['passkeySettings']
@@ -45,6 +50,15 @@ interface IProps {
     passwordSettings: NonNullable<
         GetRemnawaveSettingsCommand.Response['response']['passwordSettings']
     >
+}
+
+const DEFAULT_CLOUDFLARE_ACCESS_SETTINGS: TCloudflareAccessSettings = {
+    enabled: false,
+    teamDomain: null,
+    audience: null,
+    emailAllowlistEnabled: true,
+    allowedEmails: [],
+    allowedDomains: []
 }
 
 const getOAuth2ProvidersConfig = () =>
@@ -179,18 +193,28 @@ const getFieldConfig = (t: TFunction) =>
     }) as const
 
 export const AuthentificationSettingsCardWidget = (props: IProps) => {
-    const { passkeySettings, passwordSettings, oauth2Settings } = props
+    const {
+        passkeySettings,
+        passwordSettings,
+        oauth2Settings,
+        cloudflareAccessSettings = DEFAULT_CLOUDFLARE_ACCESS_SETTINGS
+    } = props
     const { t } = useTranslation()
     const [drawerOpened, { open: openDrawer, close: closeDrawer }] = useDisclosure(false)
 
-    const form = useForm<NonNullable<UpdateRemnawaveSettingsCommand.Request>>({
+    const form = useForm<
+        NonNullable<UpdateRemnawaveSettingsCommand.Request> & {
+            cloudflareAccessSettings: TCloudflareAccessSettings
+        }
+    >({
         name: 'auth-settings',
         mode: 'uncontrolled',
         validate: zodResolver(
-            UpdateRemnawaveSettingsCommand.RequestSchema.pick({
+            UpdateRemnawaveSettingsRequestSchema.pick({
                 passkeySettings: true,
                 passwordSettings: true,
-                oauth2Settings: true
+                oauth2Settings: true,
+                cloudflareAccessSettings: true
             })
         ),
         initialValues: {
@@ -209,7 +233,8 @@ export const AuthentificationSettingsCardWidget = (props: IProps) => {
                 keycloak: oauth2Settings.keycloak,
                 generic: oauth2Settings.generic,
                 telegram: oauth2Settings.telegram
-            }
+            },
+            cloudflareAccessSettings: cloudflareAccessSettings ?? DEFAULT_CLOUDFLARE_ACCESS_SETTINGS
         }
     })
 
@@ -223,7 +248,9 @@ export const AuthentificationSettingsCardWidget = (props: IProps) => {
                 form.setValues({
                     passkeySettings: data.passkeySettings!,
                     passwordSettings: data.passwordSettings!,
-                    oauth2Settings: data.oauth2Settings!
+                    oauth2Settings: data.oauth2Settings!,
+                    cloudflareAccessSettings:
+                        data.cloudflareAccessSettings ?? DEFAULT_CLOUDFLARE_ACCESS_SETTINGS
                 })
 
                 form.resetDirty()
@@ -274,7 +301,8 @@ export const AuthentificationSettingsCardWidget = (props: IProps) => {
             variables: {
                 passkeySettings: values.passkeySettings,
                 passwordSettings: values.passwordSettings,
-                oauth2Settings: values.oauth2Settings
+                oauth2Settings: values.oauth2Settings,
+                cloudflareAccessSettings: values.cloudflareAccessSettings
             }
         })
     })
@@ -499,6 +527,101 @@ export const AuthentificationSettingsCardWidget = (props: IProps) => {
 
                             {/* OAuth2 */}
                             {OAUTH2_PROVIDERS.map(renderOAuth2Provider)}
+
+                            {/* Cloudflare Access */}
+                            <Accordion.Item key="cloudflare-access" value="cloudflare-access">
+                                <Center>
+                                    <Accordion.Control
+                                        icon={
+                                            <ThemeIcon color="orange" size="lg" variant="light">
+                                                <SiCloudflare size={24} />
+                                            </ThemeIcon>
+                                        }
+                                    >
+                                        <Group justify="space-between" pr="md">
+                                            <Text fw={500}>Cloudflare Access</Text>
+                                        </Group>
+                                    </Accordion.Control>
+                                    <Group gap="xs" justify="flex-end" pr="xs" wrap="nowrap">
+                                        <Switch
+                                            color="teal.8"
+                                            key={form.key('cloudflareAccessSettings.enabled')}
+                                            onClick={(e) => e.stopPropagation()}
+                                            size="md"
+                                            {...form.getInputProps(
+                                                'cloudflareAccessSettings.enabled',
+                                                {
+                                                    type: 'checkbox'
+                                                }
+                                            )}
+                                        />
+                                    </Group>
+                                </Center>
+
+                                <Accordion.Panel>
+                                    <Stack gap="md">
+                                        <TextInput
+                                            description="Cloudflare Access team domain, for example team.cloudflareaccess.com"
+                                            key={form.key('cloudflareAccessSettings.teamDomain')}
+                                            label="Team domain"
+                                            placeholder="team.cloudflareaccess.com"
+                                            {...form.getInputProps(
+                                                'cloudflareAccessSettings.teamDomain'
+                                            )}
+                                        />
+
+                                        <TextInput
+                                            description="Cloudflare Access application AUD tag"
+                                            key={form.key('cloudflareAccessSettings.audience')}
+                                            label="Audience"
+                                            placeholder="0000000000000000000000000000000000000000000000000000000000000000"
+                                            {...form.getInputProps(
+                                                'cloudflareAccessSettings.audience'
+                                            )}
+                                        />
+
+                                        <CheckboxCardShared
+                                            description="When disabled, any user accepted by this Cloudflare Access application can sign in."
+                                            key={form.key(
+                                                'cloudflareAccessSettings.emailAllowlistEnabled'
+                                            )}
+                                            label="Check email allowlist"
+                                            {...form.getInputProps(
+                                                'cloudflareAccessSettings.emailAllowlistEnabled',
+                                                {
+                                                    type: 'checkbox'
+                                                }
+                                            )}
+                                        />
+
+                                        <TagsInput
+                                            clearable
+                                            description="Email addresses allowed to sign in through Cloudflare Access"
+                                            key={form.key('cloudflareAccessSettings.allowedEmails')}
+                                            label="Allowed emails"
+                                            placeholder="admin@example.com"
+                                            splitChars={[',', ' ', ';']}
+                                            {...form.getInputProps(
+                                                'cloudflareAccessSettings.allowedEmails'
+                                            )}
+                                        />
+
+                                        <TagsInput
+                                            clearable
+                                            description="Email domains allowed to sign in through Cloudflare Access"
+                                            key={form.key(
+                                                'cloudflareAccessSettings.allowedDomains'
+                                            )}
+                                            label="Allowed domains"
+                                            placeholder="example.com"
+                                            splitChars={[',', ' ', ';']}
+                                            {...form.getInputProps(
+                                                'cloudflareAccessSettings.allowedDomains'
+                                            )}
+                                        />
+                                    </Stack>
+                                </Accordion.Panel>
+                            </Accordion.Item>
                         </Accordion>
                     </SettingsCardShared.Content>
 


### PR DESCRIPTION
## Summary

Adds UI support for Cloudflare Access authentication.

This wires the frontend to the new backend Cloudflare Access auth method, adds settings controls, and automatically attempts Cloudflare Access login when the method is enabled.

## Changes

- Add Cloudflare Access section to authentication settings
- Add controls for:
  - enabled
  - team domain
  - audience
  - email allowlist toggle
  - allowed emails
  - allowed domains
- Parse Cloudflare Access fields in Remnawave settings responses
- Parse Cloudflare Access availability in auth status
- Add Cloudflare Access login hook
- Automatically attempt Cloudflare Access login on the login page when enabled

## Notes

The frontend currently extends the published backend contract schemas locally so the new fields are preserved before the backend contract package is released with these additions.

## Validation

- `git diff --check`