### PR TITLE
fix(users): clamp remaining traffic percentage at 0 for over-limit users

### DIFF
--- a/src/entities/dashboard/users/ui/table-columns/data-usage/data-usage.column.tsx
+++ b/src/entities/dashboard/users/ui/table-columns/data-usage/data-usage.column.tsx
@@ -49,7 +49,7 @@ export function DataUsageColumnEntity(props: IProps) {
                     <Text c="dimmed" component="span" fw={550} fz="xs" size="xs">
                         Σ {prettyLifetimeData}
                     </Text>{' '}
-                    {(100 - percentage).toFixed(2)}%
+                    {Math.max(0, 100 - percentage).toFixed(2)}%
                 </Text>
             </Group>
             <Progress


### PR DESCRIPTION
### Problem

In the users table, the data-usage column shows a **negative remaining percentage** when a user has consumed more than their traffic limit.

The backend allows `usedTrafficBytes` to exceed `trafficLimitBytes` (a user can go over the limit before the next reset). In that case `percentage > 100`, and the remaining figure was computed as:

```tsx
{(100 - percentage).toFixed(2)}%   // e.g. -47.50%
```

"Remaining traffic" can never be negative, so this is a display bug — e.g. a user at 147% usage shows `-47.50%` remaining.

### Fix

Clamp the remaining percentage at 0:

```tsx
{Math.max(0, 100 - percentage).toFixed(2)}%   // 0.00%
```

The **used** percentage is intentionally left unclamped so the overage (e.g. `147.50%`) stays visible — only the meaningless negative "remaining" value is corrected. The adjacent `<Progress>` already clamps internally, so only the text needed fixing.

### Verification

- `tsc --noEmit` ✅
- `eslint` ✅
- `vite build` ✅