### PR TITLE
fix(i18n): translate user status badge labels

### DIFF
--- a/public/locales/en/remnawave.json
+++ b/public/locales/en/remnawave.json
@@ -274,6 +274,14 @@
             "disconnected": "disconnected"
         }
     },
+    "user-status-badge": {
+        "widget": {
+            "active": "Active",
+            "disabled": "Disabled",
+            "expired": "Expired",
+            "limited": "Limited"
+        }
+    },
     "nodes-page-header": {
         "widget": {
             "list-of-all-nodes": "List of all nodes"

--- a/src/widgets/dashboard/users/user-status-badge/user-status-badge.widget.tsx
+++ b/src/widgets/dashboard/users/user-status-badge/user-status-badge.widget.tsx
@@ -1,30 +1,38 @@
 import { PiClockCountdown, PiClockUser, PiProhibit, PiPulse } from 'react-icons/pi'
 import { TUsersStatus, USERS_STATUS } from '@remnawave/backend-contract'
 import { Badge, BadgeProps } from '@mantine/core'
+import { useTranslation } from 'react-i18next'
 
 interface IProps extends Omit<BadgeProps, 'children' | 'color'> {
     status: TUsersStatus
 }
 
 export function UserStatusBadge({ status, ...props }: IProps) {
+    const { t } = useTranslation()
+
     let icon: React.ReactNode
     let color: BadgeProps['color'] = 'gray'
+    let label: string = status
     switch (status) {
         case USERS_STATUS.ACTIVE:
             icon = <PiPulse size={18} />
             color = 'teal'
+            label = t('user-status-badge.widget.active')
             break
         case USERS_STATUS.DISABLED:
             icon = <PiProhibit size={18} />
             color = 'shaded-gray'
+            label = t('user-status-badge.widget.disabled')
             break
         case USERS_STATUS.EXPIRED:
             icon = <PiClockUser size={18} />
             color = 'red'
+            label = t('user-status-badge.widget.expired')
             break
         case USERS_STATUS.LIMITED:
             icon = <PiClockCountdown size={18} />
             color = 'orange'
+            label = t('user-status-badge.widget.limited')
             break
         default:
             break
@@ -32,7 +40,7 @@ export function UserStatusBadge({ status, ...props }: IProps) {
 
     return (
         <Badge color={color} leftSection={icon} size="lg" variant="soft" {...props}>
-            {status}
+            {label}
         </Badge>
     )
 }


### PR DESCRIPTION
### Problem

User status labels (`Active`, `Disabled`, `Expired`, `Limited`) were always rendered in English regardless of the selected interface language, because `UserStatusBadge` printed the raw status enum value directly:

```tsx
<Badge ...>{status}</Badge>
```

Reported in remnawave/panel#191 (screenshot #1).

### Fix

Route the badge label through i18next, mirroring the existing `node-status-badge` widget which already does this. Added `user-status-badge.widget.*` keys to the English source locale; the raw `status` value is kept as a fallback for any unknown status.

Per the project's Crowdin workflow, **only the English source locale is edited** — other languages are populated via Crowdin.

### Verification

- `tsc --noEmit` ✅
- `eslint` ✅
- `prettier` ✅
- `vite build` ✅

Refs remnawave/panel#191