### PR TITLE
feat(config-profiles): apply generated reality keys to selected inbounds

### DIFF
--- a/public/locales/en/remnawave.json
+++ b/public/locales/en/remnawave.json
@@ -2203,7 +2203,15 @@
   },
   "keypair-generator": {
     "widget": {
-      "generate": "Generate"
+      "generate": "Generate",
+      "apply-to-inbounds": "Apply to inbounds",
+      "apply": "Apply",
+      "no-reality-inbounds": "No inbounds with a Reality key found in this config",
+      "invalid-config": "Config is not valid JSON",
+      "applied": "Applied a fresh key to {{count}} inbound(s)",
+      "nothing-applied": "No matching inbounds to apply keys to",
+      "success": "Success",
+      "error": "Error"
     }
   },
   "bulk-all-users-actions": {

--- a/public/locales/ru/remnawave.json
+++ b/public/locales/ru/remnawave.json
@@ -2203,7 +2203,15 @@
   },
   "keypair-generator": {
     "widget": {
-      "generate": "Сгенерировать"
+      "generate": "Сгенерировать",
+      "apply-to-inbounds": "Применить к inbound'ам",
+      "apply": "Применить",
+      "no-reality-inbounds": "В этом конфиге нет inbound'ов с ключом Reality",
+      "invalid-config": "Конфиг не является корректным JSON",
+      "applied": "Новый ключ применён к {{count}} inbound'ам",
+      "nothing-applied": "Нет подходящих inbound'ов для применения ключей",
+      "success": "Готово",
+      "error": "Ошибка"
     }
   },
   "bulk-all-users-actions": {

--- a/src/features/dashboard/config-profiles/config-editor-actions/config-editor-actions.feature.tsx
+++ b/src/features/dashboard/config-profiles/config-editor-actions/config-editor-actions.feature.tsx
@@ -304,7 +304,16 @@ export function ConfigEditorActionsFeature(props: Props) {
                                         />
                                     ),
                                     centered: true,
-                                    children: <KeypairGeneratorWidget />
+                                    children: (
+                                        <KeypairGeneratorWidget
+                                            applyConfigValue={(value) =>
+                                                editorRef.current?.setValue(value)
+                                            }
+                                            getConfigValue={() =>
+                                                editorRef.current?.getValue() ?? ''
+                                            }
+                                        />
+                                    )
                                 })
                             }}
                         >

--- a/src/widgets/dashboard/config-profiles/keypair-generator/keypair-generator.module.css
+++ b/src/widgets/dashboard/config-profiles/keypair-generator/keypair-generator.module.css
@@ -1,0 +1,35 @@
+.compactRoot {
+    position: relative;
+    padding: 8px 12px;
+    transition: all 150ms ease;
+    min-height: 48px;
+    border: 1px solid light-dark(var(--mantine-color-gray-3), var(--mantine-color-dark-4));
+
+    &[data-checked] {
+        border-color: var(--mantine-primary-color-filled);
+        background-color: light-dark(
+            var(--mantine-primary-color-light),
+            var(--mantine-primary-color-dark-color)
+        );
+    }
+
+    @mixin hover {
+        @mixin light {
+            background-color: var(--mantine-color-gray-0);
+            border-color: var(--mantine-color-gray-4);
+        }
+
+        @mixin dark {
+            background-color: var(--mantine-color-dark-6);
+            border-color: var(--mantine-color-dark-3);
+        }
+    }
+}
+
+.compactLabel {
+    font-family: var(--mantine-font-family-monospace);
+    font-weight: 600;
+    color: var(--mantine-color-bright);
+    min-width: 0;
+    flex: 1;
+}

--- a/src/widgets/dashboard/config-profiles/keypair-generator/keypair-generator.widget.tsx
+++ b/src/widgets/dashboard/config-profiles/keypair-generator/keypair-generator.widget.tsx
@@ -1,13 +1,27 @@
-import { Button, Divider, Group, px, Stack, Tabs, Transition } from '@mantine/core'
-import { useState } from 'react'
+import {
+    Alert,
+    Badge,
+    Button,
+    Checkbox,
+    Divider,
+    Group,
+    px,
+    Stack,
+    Tabs,
+    Text,
+    Transition
+} from '@mantine/core'
+import { notifications } from '@mantine/notifications'
+import { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { PiKey } from 'react-icons/pi'
-import { TbKey, TbLock, TbSignature } from 'react-icons/tb'
+import { TbAlertTriangle, TbKey, TbLock, TbPlus, TbSignature } from 'react-icons/tb'
 
 import { CopyableAreaShared } from '@shared/ui/copyable-area/copyable-area'
 import { CopyableFieldShared } from '@shared/ui/copyable-field/copyable-field'
 
 import { generateMlDsa65, generateMlKem768, generateX25519 } from './keypair-utils'
+import classes from './keypair-generator.module.css'
 
 const enum TabTypes {
     ML_DSA65 = 'ml-dsa65',
@@ -15,14 +29,252 @@ const enum TabTypes {
     X25519 = 'x25519'
 }
 
-export const KeypairGeneratorWidget = () => {
+type ApplicableTab = TabTypes.ML_DSA65 | TabTypes.X25519
+
+interface IProps {
+    applyConfigValue?: (value: string) => void
+    getConfigValue?: () => string
+}
+
+interface IRealityInbound {
+    protocol?: string
+    streamSettings?: {
+        realitySettings?: Record<string, string | undefined>
+    }
+    tag?: string
+}
+
+interface IXrayConfig {
+    inbounds?: IRealityInbound[]
+}
+
+const APPLY_FIELDS: Record<ApplicableTab, { privateField: string; publicField: string }> = {
+    [TabTypes.X25519]: { privateField: 'privateKey', publicField: 'publicKey' },
+    [TabTypes.ML_DSA65]: { privateField: 'mldsa65Seed', publicField: 'mldsa65Verify' }
+}
+
+const generateKeyPairFor = (tab: ApplicableTab): { priv: string; pub: string } => {
+    if (tab === TabTypes.X25519) {
+        const kp = generateX25519()
+        return { priv: kp.privateKey, pub: kp.password }
+    }
+    const kp = generateMlDsa65()
+    return { priv: kp.mldsa65Seed, pub: kp.mldsa65Verify }
+}
+
+const collectRealityInbounds = (
+    config: IXrayConfig | null | undefined,
+    privateField: string
+): { protocol: string; tag: string }[] => {
+    const inbounds = config?.inbounds
+    if (!Array.isArray(inbounds)) return []
+    return inbounds
+        .filter(
+            (inbound) =>
+                typeof inbound.tag === 'string' &&
+                typeof inbound.streamSettings?.realitySettings?.[privateField] === 'string'
+        )
+        .map((inbound) => ({ protocol: inbound.protocol ?? '', tag: inbound.tag as string }))
+}
+
+export const KeypairGeneratorWidget = (props: IProps) => {
+    const { applyConfigValue, getConfigValue } = props
     const { t } = useTranslation()
+
+    const canApply = Boolean(getConfigValue && applyConfigValue)
 
     const [activeTab, setActiveTab] = useState<TabTypes>(TabTypes.X25519)
 
     const [keyPair, setKeyPair] = useState(generateX25519)
     const [mlDsa65KeyPair, setMlDsa65KeyPair] = useState(generateMlDsa65)
     const [mlKem768KeyPair, setMlKem768KeyPair] = useState(generateMlKem768)
+
+    const [x25519Selection, setX25519Selection] = useState<string[]>([])
+    const [mlDsa65Selection, setMlDsa65Selection] = useState<string[]>([])
+
+    const parsedConfig = useMemo<IXrayConfig | null | undefined>(() => {
+        if (!getConfigValue) return null
+        try {
+            return JSON.parse(getConfigValue()) as IXrayConfig
+        } catch {
+            return undefined
+        }
+    }, [getConfigValue])
+
+    const realityInboundsByTab = useMemo(
+        () => ({
+            [TabTypes.X25519]: collectRealityInbounds(
+                parsedConfig,
+                APPLY_FIELDS[TabTypes.X25519].privateField
+            ),
+            [TabTypes.ML_DSA65]: collectRealityInbounds(
+                parsedConfig,
+                APPLY_FIELDS[TabTypes.ML_DSA65].privateField
+            )
+        }),
+        [parsedConfig]
+    )
+
+    const x25519Both = `"password": "${keyPair.password}",
+"privateKey": "${keyPair.privateKey}",`
+
+    const mlDsa65Both = `"mldsa65Seed": "${mlDsa65KeyPair.mldsa65Seed}",
+"mldsa65Verify": "${mlDsa65KeyPair.mldsa65Verify}",`
+
+    const applyToInbounds = (tab: ApplicableTab, selectedTags: string[]) => {
+        if (!getConfigValue || !applyConfigValue) return
+
+        let config: IXrayConfig
+        try {
+            config = JSON.parse(getConfigValue()) as IXrayConfig
+        } catch {
+            notifications.show({
+                color: 'red',
+                message: t('keypair-generator.widget.invalid-config'),
+                title: t('keypair-generator.widget.error')
+            })
+            return
+        }
+
+        const { privateField, publicField } = APPLY_FIELDS[tab]
+        const selected = new Set(selectedTags)
+        let applied = 0
+
+        for (const inbound of config.inbounds ?? []) {
+            if (!inbound.tag || !selected.has(inbound.tag)) continue
+
+            const realitySettings = inbound.streamSettings?.realitySettings
+            if (!realitySettings || typeof realitySettings[privateField] !== 'string') continue
+
+            const { priv, pub } = generateKeyPairFor(tab)
+            realitySettings[privateField] = priv
+            if (typeof realitySettings[publicField] === 'string') {
+                realitySettings[publicField] = pub
+            }
+            applied += 1
+        }
+
+        if (applied === 0) {
+            notifications.show({
+                color: 'yellow',
+                message: t('keypair-generator.widget.nothing-applied'),
+                title: t('keypair-generator.widget.error')
+            })
+            return
+        }
+
+        applyConfigValue(JSON.stringify(config, null, 2))
+        notifications.show({
+            color: 'teal',
+            message: t('keypair-generator.widget.applied', { count: applied }),
+            title: t('keypair-generator.widget.success')
+        })
+    }
+
+    const renderActions = (tab: ApplicableTab, onGenerate: () => void, selection: string[]) => {
+        const hasInbounds = canApply && realityInboundsByTab[tab].length > 0
+
+        return (
+            <Group justify={hasInbounds ? 'space-between' : 'flex-end'}>
+                <Button
+                    leftSection={<PiKey size={px('1.2rem')} />}
+                    onClick={onGenerate}
+                    size="sm"
+                    variant="default"
+                >
+                    {t('keypair-generator.widget.generate')}
+                </Button>
+
+                {hasInbounds && (
+                    <Button
+                        disabled={selection.length === 0}
+                        leftSection={<TbPlus size={px('1.2rem')} />}
+                        onClick={() => applyToInbounds(tab, selection)}
+                        size="sm"
+                    >
+                        {t('keypair-generator.widget.apply')}
+                    </Button>
+                )}
+            </Group>
+        )
+    }
+
+    const renderInboundList = (
+        tab: ApplicableTab,
+        selection: string[],
+        setSelection: (value: string[]) => void
+    ) => {
+        if (!canApply) return null
+
+        const inbounds = realityInboundsByTab[tab]
+
+        return (
+            <>
+                <Divider />
+                <Stack gap="xs">
+                    <Text fw={600} size="sm">
+                        {t('keypair-generator.widget.apply-to-inbounds')}
+                    </Text>
+
+                    {parsedConfig === undefined && (
+                        <Alert color="red" icon={<TbAlertTriangle size={16} />} variant="light">
+                            {t('keypair-generator.widget.invalid-config')}
+                        </Alert>
+                    )}
+
+                    {parsedConfig !== undefined && inbounds.length === 0 && (
+                        <Text c="dimmed" size="sm">
+                            {t('keypair-generator.widget.no-reality-inbounds')}
+                        </Text>
+                    )}
+
+                    {inbounds.length > 0 && (
+                        <Checkbox.Group onChange={setSelection} value={selection}>
+                            <Stack gap="xs">
+                                {inbounds.map((inbound) => (
+                                    <Checkbox.Card
+                                        className={classes.compactRoot}
+                                        key={inbound.tag}
+                                        radius="md"
+                                        value={inbound.tag}
+                                    >
+                                        <Group
+                                            align="center"
+                                            gap="xs"
+                                            justify="space-between"
+                                            wrap="nowrap"
+                                        >
+                                            <Group
+                                                align="center"
+                                                gap="xs"
+                                                style={{ flex: 1, minWidth: 0 }}
+                                                wrap="nowrap"
+                                            >
+                                                <Checkbox.Indicator size="sm" />
+                                                <Text
+                                                    className={classes.compactLabel}
+                                                    size="xs"
+                                                    truncate
+                                                >
+                                                    {inbound.tag}
+                                                </Text>
+                                            </Group>
+
+                                            {inbound.protocol && (
+                                                <Badge color="blue" size="md" variant="light">
+                                                    {inbound.protocol}
+                                                </Badge>
+                                            )}
+                                        </Group>
+                                    </Checkbox.Card>
+                                ))}
+                            </Stack>
+                        </Checkbox.Group>
+                    )}
+                </Stack>
+            </>
+        )
+    }
 
     return (
         <Stack gap="lg">
@@ -74,7 +326,7 @@ export const KeypairGeneratorWidget = () => {
                                         value={keyPair.password}
                                     />
                                     <CopyableFieldShared
-                                        label="Prvate Key"
+                                        label="Private Key"
                                         value={keyPair.privateKey}
                                     />
                                 </Stack>
@@ -84,21 +336,21 @@ export const KeypairGeneratorWidget = () => {
                                 <Stack gap="xs">
                                     <CopyableAreaShared
                                         label={t('keypair.widget.both-keys')}
-                                        value={`"password": "${keyPair.password}",
-"privateKey": "${keyPair.privateKey}",`}
+                                        value={x25519Both}
                                     />
                                 </Stack>
 
-                                <Group justify="flex-end">
-                                    <Button
-                                        leftSection={<PiKey size={px('1.2rem')} />}
-                                        onClick={() => setKeyPair(generateX25519)}
-                                        size="sm"
-                                        variant="default"
-                                    >
-                                        {t('keypair-generator.widget.generate')}
-                                    </Button>
-                                </Group>
+                                {renderActions(
+                                    TabTypes.X25519,
+                                    () => setKeyPair(generateX25519),
+                                    x25519Selection
+                                )}
+
+                                {renderInboundList(
+                                    TabTypes.X25519,
+                                    x25519Selection,
+                                    setX25519Selection
+                                )}
                             </Stack>
                         )}
                     </Transition>
@@ -129,22 +381,20 @@ export const KeypairGeneratorWidget = () => {
                                 <Divider />
 
                                 <Stack gap="xs">
-                                    <CopyableAreaShared
-                                        label="Both keys"
-                                        value={`"mldsa65Seed": "${mlDsa65KeyPair.mldsa65Seed}", 
-"mldsa65Verify": "${mlDsa65KeyPair.mldsa65Verify}",`}
-                                    />
+                                    <CopyableAreaShared label="Both keys" value={mlDsa65Both} />
                                 </Stack>
-                                <Group justify="flex-end">
-                                    <Button
-                                        leftSection={<PiKey size={px('1.2rem')} />}
-                                        onClick={() => setMlDsa65KeyPair(generateMlDsa65)}
-                                        size="sm"
-                                        variant="default"
-                                    >
-                                        {t('keypair.widget.generate-key-pair')}
-                                    </Button>
-                                </Group>
+
+                                {renderActions(
+                                    TabTypes.ML_DSA65,
+                                    () => setMlDsa65KeyPair(generateMlDsa65),
+                                    mlDsa65Selection
+                                )}
+
+                                {renderInboundList(
+                                    TabTypes.ML_DSA65,
+                                    mlDsa65Selection,
+                                    setMlDsa65Selection
+                                )}
                             </Stack>
                         )}
                     </Transition>


### PR DESCRIPTION
## What

Adds an "Apply" action to the keypair generator so it can write freshly generated Reality keys straight into the config, instead of copy pasting them into each inbound by hand.

On the X25519 and ML-DSA65 tabs the widget now:
- parses the current config from the editor
- lists every inbound that has the matching Reality key (`streamSettings.realitySettings.privateKey` for X25519, `mldsa65Seed` for ML-DSA65) as a checkbox list
- on Apply, generates a fresh keypair per selected inbound and writes it in

## Details

- Each selected inbound gets its own unique key, not a shared one.
- Private and public parts are kept in sync: if the inbound also has the public field (`publicKey` / `mldsa65Verify`), it is replaced with the public half of the same generated pair, so they never drift apart.
- Write back uses `JSON.stringify(config, null, 2)`, which matches how the editor already renders the config, so there is no reformatting of the document.
- Invalid JSON and configs without Reality inbounds are handled with a clear message.
- The inbound list reuses the same card style as the user internal squads list.
- ML-KEM768 is left as is: its keys live in `settings.decryption`, which is a different shape and out of scope here.

## Notes

Wiring is done through two optional props (`getConfigValue` / `applyConfigValue`) passed from the config editor, so the widget stays usable without them. i18n keys added for en and ru.

typecheck and lint pass.

## Demo

https://github.com/user-attachments/assets/397a05fe-f23a-4841-9567-e16746fa7e49

